### PR TITLE
Update eslintrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ module.exports = {
   },
   rules: {
     'comma-dangle': ['error', 'never'],
+    'complexity': ['error', { 'max': 10 }],
     'function-paren-newline': 'off',
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
+    'import/no-named-as-default': 0,
     'import/no-unresolved': 'off',
     'import/prefer-default-export': 'off',
     'jsx-a11y/anchor-is-valid': 'warn',

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     'function-paren-newline': 'off',
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
-    'import/no-named-as-default': 0,
+    'import/no-named-as-default': 'off',
     'import/no-unresolved': 'off',
     'import/prefer-default-export': 'off',
     'jsx-a11y/anchor-is-valid': 'warn',


### PR DESCRIPTION
Removed inherited rule
"import/no-named-as-default": 0,

AND added useful rule about cyclomatic complexity set to a value that is not bad (10),

actually there are three functions that violates it, but for those I added the es-lint-ignore specific block-comments