### PR TITLE
Install with peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ ESLint and Prettier config
 
 ## Integration
 
-- `yarn add --dev @verkstedt/eslint-config-verkstedt@latest`
+- Install the package along with it’s peer dependencies:
+
+  ```sh
+  npx install-peerdeps --yarn --dev @verkstedt/eslint-config-verkstedt
+  ```
 
 - If your project uses TypeScript:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "@typescript-eslint/parser": "^5.10.0",
     "typescript": "^4.5.4"
   },
+  "peerDependencies": {
+    "eslint-plugin-prettier": "^4.0.0"
+  },
   "optionalDependencies": {
     "@babel/core": "^7.16.7",
     "@babel/eslint-parser": "^7.16.5",


### PR DESCRIPTION
At the moment it’s only prettier plugin, because other dependencies differ whether project uses TS or not.