### PR TITLE
Add no-redeclare rules for typescript

### DIFF
--- a/lib/withTypescript.js
+++ b/lib/withTypescript.js
@@ -34,6 +34,9 @@ module.exports = (base) => ({
             allowInGenericTypeArguments: true,
           },
         ],
+        // The following "no-redeclare" rules stop errors being flagged on function overloads
+        'no-redeclare': 'off',
+        '@typescript-eslint/no-redeclare': ['error'],
         // @typescript-eslint rules counterparts
         ...['no-shadow', 'no-unused-vars'].reduce(
           (rules, name) => ({

--- a/lib/withTypescript.js
+++ b/lib/withTypescript.js
@@ -34,11 +34,8 @@ module.exports = (base) => ({
             allowInGenericTypeArguments: true,
           },
         ],
-        // The following "no-redeclare" rules stop errors being flagged on function overloads
-        'no-redeclare': 'off',
-        '@typescript-eslint/no-redeclare': ['error'],
         // @typescript-eslint rules counterparts
-        ...['no-shadow', 'no-unused-vars'].reduce(
+        ...['no-shadow', 'no-unused-vars', 'no-redeclare'].reduce(
           (rules, name) => ({
             ...rules,
             [name]: 'off',


### PR DESCRIPTION
# Why?

Currently function overloads cause eslint errors