### PR TITLE
Update README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ESLint and Prettier config
 
 - Add the following to `stylelint.config.cjs`:
   ```js
-  module.exports = require('@verkstedt/eslint-config-verkstedt/stylelint-config')
+  module.exports = require('@verkstedt/eslint-config-verkstedt/stylelint-config.cjs')
   ```
 
 ## Upgrading


### PR DESCRIPTION
# Why?

The stylelint extend field no longer works without the `cjs` extension.