### PR TITLE
Fix @typescript-eslint/no-redeclare

### DIFF
--- a/base.js
+++ b/base.js
@@ -39,6 +39,7 @@ const config = {
     ],
     'no-shadow': ['error'],
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-redeclare': ['error'],
     'no-debugger': 'warn',
     'no-else-return': 'off',
     'no-restricted-imports': [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "ESLint config",
   "main": "index.js",
   "scripts": {
+    "test": "npm-run-all 'test:*'",
+    "test:unit": "node --test ./test.mjs",
     "lint": "npm-run-all 'lint:*'",
     "lint:js": "eslint .",
     "lint:deps": "node ./validate-deps.js"

--- a/test-input.ts
+++ b/test-input.ts
@@ -1,0 +1,1 @@
+// Used for testing

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S node --test
+
+import assert from 'node:assert'
+import { resolve } from 'node:path'
+import { describe, it, beforeEach } from 'node:test'
+
+import EsLintModule from 'eslint'
+
+const { ESLint } = EsLintModule
+
+describe('EsLint', () => {
+  describe('preset: typescript', () => {
+    /** @type {ESLint} */
+    let eslint
+
+    beforeEach(() => {
+      eslint = new ESLint({
+        overrideConfigFile: resolve('./typescript.js'),
+      })
+    })
+
+    it('works on an empty file', async () => {
+      const input = ''
+
+      const [result] = await eslint.lintText(input, {
+        filePath: './test-input.ts',
+      })
+
+      assert.deepEqual(result.messages, [])
+    })
+
+    it('has working @typescript-eslint/no-redeclare', async () => {
+      const input = `
+const redeclared = 'foo'
+const redeclared = 'bar'
+
+export { redeclared }
+`.trimStart()
+
+      const [result] = await eslint.lintText(input, {
+        filePath: './test-input.ts',
+      })
+
+      assert.strictEqual(result.messages.length, 1)
+      assert.strictEqual(
+        result.messages[0].ruleId,
+        '@typescript-eslint/no-redeclare'
+      )
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "files": ["./test-input.ts"]
+}


### PR DESCRIPTION
# Why?

Fixes https://verkstedt.atlassian.net/browse/VIP-25

For few TS rules we copy the values from their non–TS counterparts. This
assumes that these values are defined in our base config, because with
old style of EsLint config format you don’t get values from presets you
are extending.

In ee6069c1081e0fa8b259688f0e885815ccbedc48 we did a mistake of using
`no-redeclare`, but it was defined in a preset we are extending
(`airbnb-base`), not in our, so it was `undefined`.

This PR also adds some stub tests to avoid regressions.
