### PR TITLE
docs: exclude verkstedt/lint repo from “packages using this” search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Linting configuration for verkstedt projects
 
 ## Links
 
-- [🔍 Packages using this](https://github.com/search?q=path:**/package.json+%22@verkstedt/lint%22+NOT+is:archived)
+- [🔍 Packages using this](https://github.com/search?q=path:**/package.json+%22@verkstedt/lint%22+NOT+repo:verkstedt/lint+NOT+is:archived)
 
 <details>
 <summary>verkstedt internal</summary>


### PR DESCRIPTION
## Why?

The “packages using this” link in the README searches GitHub for `package.json` files referencing `@verkstedt/lint`. That search also matched this repo itself (which declares the package name), adding noise to the list of *consumers*.

## What?

Added `NOT repo:verkstedt/lint` to the search query so the repo is excluded from its own usage search.

---

```
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
```