### PR TITLE
chore(prettier): ignore BMAD skill directories

### DIFF
--- a/prettier/.prettierignore
+++ b/prettier/.prettierignore
@@ -18,6 +18,8 @@ next-env.d.ts
 # BMAD method
 /_bmad/
 /_bmad-output/
+/.agents/skills/bmad*/
+/.claude/skills/bmad*/
 /.claude/commands/bmad-*.md
 /.cursor/commands/bmad-*.md
 /.codex/prompts/bmad-*.md


### PR DESCRIPTION
## Why?

BMAD method generates skill files under `.agents/skills/bmad*/` and `.claude/skills/bmad*/`. These are generated artefacts that should not be reformatted by Prettier — consistent with the existing BMAD entries already in the ignore file.

## What?

Added `/.agents/skills/bmad*/` and `/.claude/skills/bmad*/` to `prettier/.prettierignore`.

---

```
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
```