### PR TITLE
feat: recognise wrangler.jsonc as a Microsoft JSONC file

### DIFF
--- a/eslint/file-globs.ts
+++ b/eslint/file-globs.ts
@@ -14,7 +14,11 @@ export const CSS_FILES = [`**/*.css`];
 const JSON_EXTS = ['json', 'jsonc'];
 export const JSON_FILES = [`**/*.{${JSON_EXTS.join(',')}}`];
 
-export const MS_JSONC_FILES = ['tsconfig.json', '.vscode/**/*.json'];
+export const MS_JSONC_FILES = [
+  'tsconfig.json',
+  'wrangler.jsonc',
+  '.vscode/**/*.json',
+];
 export const JSONC_FILES = ['**/*.jsonc', ...MS_JSONC_FILES];
 
 const MARKDOWN_EXTS = ['md', 'markdown'];


### PR DESCRIPTION
## Why?

Cloudflare’s `wrangler.jsonc` is a JSONC file (it allows comments and trailing
commas) but, unlike `**/*.jsonc`, it uses the plain `.jsonc`-less-looking name
convention only in the sense of being a well-known tool config. It was not being
treated as a Microsoft-flavoured JSONC file, so it missed the same handling as
`tsconfig.json` and `.vscode/**/*.json`.

## What?

Add `wrangler.jsonc` to `MS_JSONC_FILES` so it is linted as JSONC alongside the
other Microsoft-flavoured JSONC files.

@coderabbitai ignore

---

```
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
