### PR TITLE
feat: enable tolerant CSS parsing

### DIFF
--- a/eslint/index.ts
+++ b/eslint/index.ts
@@ -650,6 +650,11 @@ async function createVerkstedtConfig({
           files: CSS_FILES,
           plugins: { css },
           language: 'css/css',
+          languageOptions: {
+            // Allows syntax errors that browser can recover from.
+            // This is to enable syntax not yet recognised by the parser.
+            tolerant: true,
+          },
           extends: ['css/recommended'],
         };
       },


### PR DESCRIPTION
## Why?

The CSS parser rejects syntax it does not yet recognise, which flags valid,
browser-recoverable CSS (e.g. newer features not yet known to the parser) as
errors.

## What?

Enable `languageOptions.tolerant = true` on the CSS config block so the parser
recovers from syntax errors a browser could recover from, allowing not-yet-known
CSS syntax through.

@coderabbitai ignore

---

```
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
